### PR TITLE
Move tokio-uds-ipc to a new repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,812 @@
 version = 4
 
 [[package]]
+name = "abort-on-drop"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd6d700ad9af641490c1f7d67980d2de4d1433016e5b12f819448d3c832142a"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "backtrace"
+version = "0.3.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.172"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "postcard"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+
+[[package]]
+name = "socket2"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "tokio"
+version = "1.44.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "tokio-uds-ipc"
 version = "0.1.0"
+dependencies = [
+ "abort-on-drop",
+ "futures",
+ "postcard",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "type_traits",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-util",
+ "hashbrown",
+ "pin-project-lite",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
+name = "type_traits"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4ac82d4642aaf179246f07adae5b776e11bfafa464eee72ee616c4eabca3a9"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,48 @@ edition = "2024"
 [lib]
 
 [dependencies]
+abort-on-drop = "0.2.2"
+futures = "0.3.31"
+postcard = { version = "1.1.1", default-features = false, features = ["use-std"] }
+serde = { version = "1.0.204", features = ["derive", "rc"] }
+thiserror = "2.0.12"
+tokio = { version = "1.38.1", features = ["full"] }
+tokio-stream = { version = "0.1.15", features = ["full"] }
+tokio-util = { version = "0.7.11", features = ["full"] }
+tracing = "0.1.40"
+type_traits = "0.3.0"
+
+[dev-dependencies]
+tracing-subscriber = { version = "0.3.18", features = [ "default", "json", "env-filter", "fmt" ] }
+
+[lints.rust]
+missing_docs = "warn"
+impl-trait-overcaptures = "deny"
+
+[lints.clippy]
+arithmetic_side_effects = "warn"
+assigning_clones = "warn"
+branches_sharing_code = "warn"
+cast_lossless = "warn"
+cast_possible_wrap = "warn"
+infinite_iter = "warn"
+infinite_loop = "warn"
+manual_string_new = "warn"
+missing_const_for_fn = "warn"
+missing_panics_doc = "warn"
+missing_safety_doc = "warn"
+needless_bitwise_bool = "warn"
+needless_collect = "warn"
+needless_continue = "warn"
+needless_for_each = "warn"
+needless_pass_by_ref_mut = "warn"
+needless_pass_by_value = "warn"
+redundant_clone = "warn"
+semicolon_if_nothing_returned = "warn"
+significant_drop_in_scrutinee = "warn"
+unnecessary_wraps = "warn"
+use_self = "warn"
+allow_attributes = "warn"
 
 [features]
 default = []

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,157 @@
+//! Client for a UDS service.
+
+mod robust;
+
+use std::{ops::RangeInclusive, path::Path, time::Duration};
+
+use futures::{Sink, SinkExt, Stream, StreamExt};
+use serde::{Serialize, de::DeserializeOwned};
+use tokio::net::UnixStream;
+use tokio_util::codec::Framed;
+
+use crate::comm::{CodecError, PostcardCodec};
+
+pub use self::robust::{RobustClient, SplitSinkOwned, SplitStreamOwned};
+
+/// Generic unix domain socket client. Takes a `Request` and `Response` types.
+/// The former is something sent to the server, the latter is what the server
+/// sends back.
+pub struct Client<Request, Response> {
+    pub(crate) inner: Framed<UnixStream, PostcardCodec<Request, Response>>,
+}
+
+/// Trait for [Client::new_retry] interval argument.
+pub trait RetryInterval {
+    fn into_range(self) -> RangeInclusive<Duration>;
+}
+
+impl RetryInterval for Duration {
+    fn into_range(self) -> RangeInclusive<Duration> {
+        self..=self
+    }
+}
+
+impl RetryInterval for RangeInclusive<Duration> {
+    fn into_range(self) -> RangeInclusive<Duration> {
+        self
+    }
+}
+
+// NB: the trait is not actually exported from the crate by design. Rustc
+// complains (as in, gives a complie-time error) if a pub type synonym
+// references an associated type in a private trait. It doesn't if the trait is
+// pub but not exported though, which is what we use here.
+pub trait ServerTypeTrait {
+    type ServerType;
+    type RobustType;
+}
+
+impl<Req, Resp> ServerTypeTrait for Client<Req, Resp> {
+    type ServerType = crate::Server<Req, Resp>;
+    type RobustType = crate::RobustClient<Req, Resp>;
+}
+
+/// Get a [crate::Server] type for the given [Client].
+pub type ServerType<Client> = <Client as ServerTypeTrait>::ServerType;
+
+/// Get a [crate::RobustClient] type for the given [Client].
+pub type RobustType<Client> = <Client as ServerTypeTrait>::RobustType;
+
+impl<Request, Response> Client<Request, Response> {
+    /// Make a new [Client] using the socket at the given path.
+    pub async fn new(socket_path: &Path) -> Result<Self, std::io::Error> {
+        #[expect(path_statements)]
+        {
+            type_traits::Assert::<Request>::IS_NOT_ZST;
+            type_traits::Assert::<Response>::IS_NOT_ZST;
+        }
+
+        let sock = UnixStream::connect(socket_path).await?;
+        Ok(Self {
+            inner: Framed::new(sock, PostcardCodec::new()),
+        })
+    }
+
+    /// As [Self::new], but will retry on error until success. Will use
+    /// exponential backoff. If `retry_interval` is just [Duration], then backoff is
+    /// disabled.
+    ///
+    /// The delay between retries starts at
+    /// `min_backoff`, and doubles on each retry, until it reaches `max_backoff`. If
+    /// the inner tasks at any point runs for longer than `current_backoff`, the
+    /// backoff will reset back to `min_backoff`.
+    pub async fn new_retry(socket_path: &Path, retry_interval: impl RetryInterval) -> Self {
+        crate::utils::retry_with_backoff(retry_interval.into_range(), || async {
+            Self::new(socket_path)
+                .await
+                .inspect_err(|err| {
+                    tracing::error!(
+                        ?err,
+                        "Failed to connect to {}",
+                        socket_path.to_string_lossy()
+                    );
+                })
+                .ok()
+        })
+        .await
+    }
+
+    /// Construct a new [RobustClient].
+    pub fn new_robust(
+        socket_path: &Path,
+        retry_interval: impl RetryInterval + Send + Clone + 'static,
+    ) -> RobustClient<Request, Response>
+    where
+        Response: DeserializeOwned + Send + 'static,
+        Request: Serialize + Send + Sync + 'static,
+    {
+        RobustClient::new(socket_path, retry_interval)
+    }
+}
+
+impl<Request, Response> Stream for Client<Request, Response>
+where
+    Response: DeserializeOwned,
+{
+    type Item = Result<Response, CodecError>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.inner.poll_next_unpin(cx)
+    }
+}
+
+impl<T, Request, Response> Sink<T> for Client<Request, Response>
+where
+    T: std::borrow::Borrow<Request>,
+    Request: Serialize,
+{
+    type Error = CodecError;
+
+    fn poll_ready(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready_unpin(cx)
+    }
+
+    fn start_send(mut self: std::pin::Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
+        self.inner.start_send_unpin(item.borrow())
+    }
+
+    fn poll_flush(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_flush_unpin(cx)
+    }
+
+    fn poll_close(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_close_unpin(cx)
+    }
+}

--- a/src/client/robust.rs
+++ b/src/client/robust.rs
@@ -1,0 +1,205 @@
+use std::{
+    convert::Infallible,
+    path::Path,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use abort_on_drop::ChildTask;
+use futures::{Sink, SinkExt, Stream, StreamExt as _, never::Never};
+use serde::{Serialize, de::DeserializeOwned};
+use tokio::sync::mpsc;
+use tokio_util::sync::{PollSendError, PollSender};
+
+use super::{Client, RetryInterval};
+
+type MappedPollSink<Request> =
+    futures::sink::SinkMapErr<PollSender<Request>, fn(PollSendError<Request>) -> Infallible>;
+
+/// Robust client that will seamlessly reconnect on failures.
+pub struct RobustClient<Request, Response> {
+    incoming: mpsc::Receiver<Response>,
+    outgoing: MappedPollSink<Request>,
+    client_loop: ChildTask<Never>,
+}
+
+impl<Request, Response> RobustClient<Request, Response>
+where
+    Response: DeserializeOwned + Send + 'static,
+    Request: Serialize + Send + Sync + 'static,
+{
+    /// Construct a new [RobustClient].
+    pub fn new(
+        socket_path: &Path,
+        retry_interval: impl RetryInterval + Send + Clone + 'static,
+    ) -> Self {
+        let socket_path = socket_path.to_owned();
+        let (incoming_tx, incoming_rx) = mpsc::channel(10);
+        let (outgoing_tx, outgoing_rx) = mpsc::channel(10);
+        let mut out_stream = tokio_stream::wrappers::ReceiverStream::new(outgoing_rx);
+        let client_loop = async move {
+            let mut pending = None;
+            'outer: loop {
+                // split() will break lifetimes, and we want lifetimes...
+                let mut client =
+                    Client::<Request, Response>::new_retry(&socket_path, retry_interval.clone())
+                        .await;
+                let mut stream = futures::stream::iter(pending.take())
+                    .chain(&mut out_stream)
+                    .fuse();
+                loop {
+                    tokio::select! {
+                        // if stream ends, then the sink part got dropped. We
+                        // just ignore this branch then. Stream is fused, so
+                        // this is safe, if a tad inefficient. Generally, this
+                        // won't happen, as recv-only stream is already
+                        // implemented on Self.
+                        Some(next) = stream.next() => {
+                            if let Err(e) = client.send(&next).await {
+                                pending = Some(next);
+                                tracing::error!(?e);
+                                continue 'outer;
+                            }
+                        },
+                        res = client.next() => {
+                            let next = match res {
+                                Some(Ok(x)) => x,
+                                Some(Err(e)) => {
+                                    tracing::error!(?e);
+                                    continue 'outer;
+                                }
+                                None => continue 'outer,
+                            };
+                            if incoming_tx.send(next).await.is_err() {
+                                // incoming_tx is closed, but maybe that's by
+                                // design; just ignore it.
+                                continue;
+                            }
+                        },
+                    }
+                }
+            }
+        };
+        Self {
+            incoming: incoming_rx,
+            outgoing: PollSender::new(outgoing_tx).sink_map_err(|e| {
+                unreachable!("Error should be impossible here: {e}");
+            }),
+            client_loop: ChildTask::from(tokio::spawn(client_loop)),
+        }
+    }
+
+    /// Produce a [Sink] for requests.
+    pub fn sink(&mut self) -> impl Sink<Request, Error = Infallible> + use<'_, Request, Response> {
+        &mut self.outgoing
+    }
+
+    /// Produce a [Sink] for requests and [Stream] for responses. Borrowing
+    /// version. Should be slightly more efficient than [Self::split_owned].
+    pub fn split_borrowed(
+        &mut self,
+    ) -> (
+        impl Sink<Request, Error = Infallible> + use<'_, Request, Response>,
+        impl Stream<Item = Response> + use<'_, Request, Response>,
+    ) {
+        (&mut self.outgoing, SplitStream(&mut self.incoming))
+    }
+
+    /// Produce a [Sink] for requests and [Stream] for responses. Owned version.
+    pub fn split_owned(self) -> (SplitSinkOwned<Request>, SplitStreamOwned<Response>) {
+        let task = Arc::new(self.client_loop);
+        (
+            SplitSinkOwned {
+                inner: self.outgoing,
+                _task: Arc::clone(&task),
+            },
+            SplitStreamOwned {
+                inner: self.incoming,
+                _task: task,
+            },
+        )
+    }
+}
+
+impl<Request, Response> Stream for RobustClient<Request, Response>
+where
+    Response: DeserializeOwned,
+{
+    type Item = Response;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.incoming.poll_recv(cx)
+    }
+}
+
+struct SplitStream<'a, T>(&'a mut mpsc::Receiver<T>);
+
+impl<T> Stream for SplitStream<'_, T> {
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.0.poll_recv(cx)
+    }
+}
+
+/// The sink part of the [RobustClient], owned version.
+pub struct SplitSinkOwned<Request> {
+    inner: MappedPollSink<Request>,
+    _task: Arc<ChildTask<Never>>,
+}
+
+impl<Request> SplitSinkOwned<Request> {
+    /// A convenient function to send message once, using only shared reference,
+    /// unlike [SinkExt::send].
+    #[expect(clippy::missing_panics_doc)]
+    pub async fn send_ref(&self, msg: Request)
+    where
+        Request: Send,
+    {
+        self.inner
+            .get_ref()
+            .get_ref()
+            .expect("Must be open by construction")
+            .send(msg)
+            .await
+            .expect("Receiver part isn't dropped until self");
+    }
+}
+
+impl<Request> Sink<Request> for SplitSinkOwned<Request>
+where
+    MappedPollSink<Request>: Sink<Request, Error = Infallible> + Unpin,
+{
+    type Error = Infallible;
+
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready_unpin(cx)
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: Request) -> Result<(), Self::Error> {
+        self.inner.start_send_unpin(item)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_flush_unpin(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_close_unpin(cx)
+    }
+}
+
+/// The stream part of the [RobustClient], owned version.
+pub struct SplitStreamOwned<Response> {
+    inner: mpsc::Receiver<Response>,
+    _task: Arc<ChildTask<Never>>,
+}
+
+impl<Response> Stream for SplitStreamOwned<Response> {
+    type Item = Response;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.poll_recv(cx)
+    }
+}

--- a/src/comm.rs
+++ b/src/comm.rs
@@ -1,0 +1,74 @@
+//! Communication protocol for a generic UDS service.
+
+use std::marker::PhantomData;
+
+use serde::{Serialize, de::DeserializeOwned};
+use tokio_util::bytes::{Buf, BufMut};
+
+/// Errors produced by codec.
+#[derive(Debug, thiserror::Error)]
+pub enum CodecError {
+    /// IO error.
+    #[error("{0}")]
+    Io(#[from] std::io::Error),
+    /// Encoding/decoding failed.
+    #[error("Encoding/decoding failed: {0}")]
+    Postcard(#[from] postcard::Error),
+}
+
+/// A codec that uses [postcard] crate to serialize/deserialize.
+///
+/// It fits when the decoded messages are not too large, which is the case here.
+pub struct PostcardCodec<E, D> {
+    _ser_phantom: PhantomData<E>,
+    _de_phantom: PhantomData<D>,
+}
+
+impl<E, D> Default for PostcardCodec<E, D> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<E, D> PostcardCodec<E, D> {
+    /// Construct a codec from the options.
+    pub const fn new() -> Self {
+        Self {
+            _ser_phantom: PhantomData,
+            _de_phantom: PhantomData,
+        }
+    }
+}
+
+impl<E, D: DeserializeOwned> tokio_util::codec::Decoder for PostcardCodec<E, D> {
+    type Item = D;
+    type Error = CodecError;
+
+    fn decode(
+        &mut self,
+        src: &mut tokio_util::bytes::BytesMut,
+    ) -> Result<Option<Self::Item>, Self::Error> {
+        match postcard::take_from_bytes(src) {
+            Err(postcard::Error::DeserializeUnexpectedEnd) => Ok(None),
+            Ok((res, rest)) => {
+                let frame_len = src.len().saturating_sub(rest.len());
+                src.advance(frame_len);
+                Ok(Some(res))
+            }
+            Err(e) => Err(Self::Error::from(e)),
+        }
+    }
+}
+
+impl<E: Serialize, D> tokio_util::codec::Encoder<&E> for PostcardCodec<E, D> {
+    type Error = CodecError;
+
+    fn encode(
+        &mut self,
+        item: &E,
+        dst: &mut tokio_util::bytes::BytesMut,
+    ) -> Result<(), Self::Error> {
+        postcard::to_io(item, dst.writer())?;
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+//! Generic UDS client/server implementation for IPC
+
+mod client;
+mod comm;
+mod server;
+pub(crate) mod utils;
+
+pub use client::{Client, RobustClient, RobustType, ServerType, SplitSinkOwned, SplitStreamOwned};
+pub use comm::CodecError;
+pub use server::{Error, IndependentHandlers, RequestStream, Server, independent_handlers, serve};

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,393 @@
+//! Server implementation.
+
+use std::{marker::PhantomData, os::unix::fs::PermissionsExt, path::Path, sync::Arc};
+
+use abort_on_drop::ChildTask;
+use futures::{Stream, StreamExt, never::Never};
+use tokio::{
+    net::{UnixListener, UnixStream},
+    task::JoinError,
+};
+use tokio_util::codec::Framed;
+
+use crate::comm::{CodecError, PostcardCodec};
+
+/// Server errors.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Found existing socket, likely from the previous run, but failed to remove it.
+    #[error("Found existing socket, likely from the previous run, but failed to remove it: {0}")]
+    RmStaleSock(std::io::Error),
+
+    /// Could not create parent directories for the socket path.
+    #[error("Could not create parent directories for the socket path: {0}")]
+    MkParentDir(std::io::Error),
+
+    ///Could not bind to the socket
+    #[error("Could not bind to the socket {socket}: {source}")]
+    SocketBind {
+        /// Underlying IO error
+        source: std::io::Error,
+        /// Socket we tried to bind to.
+        socket: String,
+    },
+
+    /// Could not set permissions on the socket
+    #[error("Could not set permissions on the socket {socket}: {source}")]
+    SetSocketPermissions {
+        /// Underlying IO error
+        source: std::io::Error,
+        /// Socket we tried to set permissions on.
+        socket: String,
+    },
+
+    /// Error in codec.
+    #[error("Codec error: {0}")]
+    Codec(#[from] CodecError),
+}
+
+/// Server handle. If dropped, the server will shut down.
+pub struct Server<Request, Response> {
+    task: ChildTask<Never>,
+    num_clients: tokio::sync::watch::Receiver<usize>,
+    _phantom: PhantomData<fn(Request) -> Response>,
+}
+
+impl<Request, Response> Server<Request, Response> {
+    /// Get a [tokio::sync::watch::Receiver] for the current number of clients.
+    pub fn num_clients(&self) -> tokio::sync::watch::Receiver<usize> {
+        self.num_clients.clone()
+    }
+
+    /// Wait for the server to exit; It will only exit if it panics though,
+    /// which it normally shouldn't.
+    pub async fn join(self) -> JoinError {
+        let Err(e) = self.task.await;
+        e
+    }
+}
+
+/// A concrete type we pass a the request stream to the handler callback. Could
+/// be a `BoxStream`, but for now it's more specific to save on `dyn` overhead.
+type RequestStreamInner<Request, Response> = futures::stream::FilterMap<
+    futures::stream::SplitStream<crate::Client<Response, Request>>,
+    std::future::Ready<Option<Request>>,
+    fn(Result<Request, CodecError>) -> std::future::Ready<Option<Request>>,
+>;
+
+/// An opaque wrapper for the [serve] callback argument. A [Stream] of requests.
+pub struct RequestStream<Request, Response>(RequestStreamInner<Request, Response>);
+
+impl<Request, Response> Stream for RequestStream<Request, Response>
+where
+    RequestStreamInner<Request, Response>: Stream<Item = Request>,
+{
+    type Item = Request;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.0.poll_next_unpin(cx)
+    }
+}
+
+/// Run the server at the given socket path. Accepts the following arguments:
+///
+/// - Path to the socket to create.
+/// - A function to create a response stream from a request stream.
+///
+/// The last argument is a function, and not just a stream and sink, because it
+/// needs to be created on-demand per-client. We can't share the same
+/// request/response streams between multiple clients.
+pub fn serve<Request, Response, S>(
+    socket: &Path,
+    handler: impl Fn(RequestStream<Request, Response>) -> S + Send + Sync + 'static,
+) -> Result<Server<Request, Response>, Error>
+where
+    Request: for<'de> serde::Deserialize<'de> + Send,
+    Response: serde::Serialize + Send,
+    S: Stream<Item = Response> + Send,
+{
+    #[expect(path_statements)]
+    {
+        type_traits::Assert::<Request>::IS_NOT_ZST;
+        type_traits::Assert::<Response>::IS_NOT_ZST;
+    }
+
+    if socket.exists() {
+        std::fs::remove_file(socket).map_err(Error::RmStaleSock)?;
+    }
+    if let Some(parent) = socket.parent() {
+        std::fs::create_dir_all(parent).map_err(Error::MkParentDir)?;
+    }
+    let listener = UnixListener::bind(socket).map_err(|e| Error::SocketBind {
+        source: e,
+        socket: socket.display().to_string(),
+    })?;
+
+    std::fs::set_permissions(socket, std::fs::Permissions::from_mode(0o666)).map_err(|e| {
+        Error::SocketBind {
+            source: e,
+            socket: socket.display().to_string(),
+        }
+    })?;
+
+    let (num_clients_tx, num_clients_rx) = tokio::sync::watch::channel(0);
+
+    Ok(Server {
+        task: ChildTask::from(tokio::spawn(async move {
+            serve_loop(listener, handler, num_clients_tx).await
+        })),
+        num_clients: num_clients_rx,
+        _phantom: PhantomData,
+    })
+}
+
+async fn serve_loop<Request, Response, S>(
+    listener: UnixListener,
+    handler: impl Fn(RequestStream<Request, Response>) -> S + Send + Sync + 'static,
+    num_clients: tokio::sync::watch::Sender<usize>,
+) -> !
+where
+    Request: for<'de> serde::Deserialize<'de> + Send,
+    Response: serde::Serialize + Send,
+    S: Stream<Item = Response> + Send,
+{
+    let handler = Arc::new(handler);
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let cancelled = cancel.child_token();
+    let _cancel_guard = cancel.drop_guard();
+    loop {
+        let (client, addr) = match listener.accept().await {
+            Ok(sock) => sock,
+            Err(err) => {
+                tracing::error!(?err, "Client connection failed");
+                continue;
+            }
+        };
+        tracing::info!("Client {addr:?} connected");
+        tokio::spawn({
+            let handler = handler.clone();
+            let num_clients = num_clients.clone();
+            let cancelled = cancelled.clone();
+            async move {
+                num_clients.send_modify(|x| {
+                    *x = x.saturating_add(1);
+                });
+                let res = tokio::select! {
+                    res = serve_connection(client, handler.as_ref()) => res,
+                    _ = cancelled.cancelled() => Ok(()),
+                };
+                if let Err(err) = res {
+                    tracing::error!(?err, "Client connection completed with an error");
+                }
+                num_clients.send_modify(|x| {
+                    *x = x.saturating_sub(1);
+                });
+            }
+        });
+    }
+}
+
+async fn serve_connection<Request, Response, S>(
+    sock: UnixStream,
+    handler: impl Fn(RequestStream<Request, Response>) -> S,
+) -> Result<(), Error>
+where
+    Request: for<'de> serde::Deserialize<'de>,
+    Response: serde::Serialize,
+    S: Stream<Item = Response>,
+{
+    let io = crate::Client {
+        inner: Framed::new(sock, PostcardCodec::<Response, Request>::new()),
+    };
+
+    let (sink, stream) = io.split();
+
+    fn filter_errs<Request>(
+        msg: Result<Request, CodecError>,
+    ) -> std::future::Ready<Option<Request>> {
+        std::future::ready(match msg {
+            Ok(msg) => Some(msg),
+            Err(err) => {
+                tracing::error!(?err, "Decoding an incoming message failed");
+                None
+            }
+        })
+    }
+
+    let request_stream = stream.filter_map(
+        filter_errs::<Request>
+            as fn(Result<Request, CodecError>) -> std::future::Ready<Option<Request>>,
+    );
+
+    handler(RequestStream(request_stream))
+        .map(Ok)
+        .forward(sink)
+        .await?;
+
+    Ok(())
+}
+
+/// Make a callback for [serve] that constructs the response stream
+/// independently of handling the request stream. Both request and response
+/// streams are still polled in the same task, and the request stream will be
+/// exhausted before the next poll of the response stream. Avoid blocking in
+/// request handler, as it will block the response stream as well.
+pub fn independent_handlers<Request, Response, S, F>(
+    request_handler: F,
+    response_stream: impl Fn() -> S,
+) -> impl Fn(RequestStream<Request, Response>) -> IndependentHandlers<Request, Response, S, F>
+where
+    F: Fn(Request),
+    S: Stream<Item = Response>,
+    RequestStream<Request, Response>: Stream<Item = Request>,
+{
+    let request_handler = Arc::new(request_handler);
+    move |req: RequestStream<Request, Response>| IndependentHandlers {
+        handler: Arc::clone(&request_handler),
+        req: req.fuse(),
+        resp: response_stream(),
+    }
+}
+
+/// Return stream type for [independent_handlers].
+pub struct IndependentHandlers<Request, Response, S, F> {
+    handler: Arc<F>,
+    req: futures::stream::Fuse<RequestStream<Request, Response>>,
+    resp: S,
+}
+
+impl<Request, Response, S, F> Stream for IndependentHandlers<Request, Response, S, F>
+where
+    RequestStream<Request, Response>: Stream<Item = Request>,
+    S: Stream<Item = Response> + Unpin,
+    F: Fn(Request) + Unpin,
+{
+    type Item = Response;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        while let std::task::Poll::Ready(Some(msg)) = self.as_mut().req.poll_next_unpin(cx) {
+            (self.handler)(msg);
+        }
+        self.resp.poll_next_unpin(cx)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::client::Client;
+
+    use super::*;
+
+    use std::{path::Path, time::Duration};
+
+    use futures::SinkExt;
+    use serde::{Deserialize, Serialize};
+    use tokio::sync::broadcast;
+
+    #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+    struct Resp {
+        foo: String,
+        bar: String,
+    }
+
+    #[derive(Deserialize, Serialize)]
+    struct Req {
+        foo: String,
+        bar: String,
+    }
+
+    #[tokio::test]
+    async fn test_comm() {
+        let sock_path = Path::new("/tmp/uds-client-server.sock");
+
+        let (tx, rx) = broadcast::channel(100);
+
+        let handler = independent_handlers(
+            move |msg: Req| {
+                let _ = tx.send(Resp {
+                    foo: msg.bar,
+                    bar: msg.foo,
+                });
+            },
+            move || {
+                tokio_stream::wrappers::BroadcastStream::new(rx.resubscribe())
+                    .filter_map(|x| std::future::ready(x.ok()))
+            },
+        );
+
+        let _server = serve::<Req, Resp, _>(sock_path, handler).unwrap();
+
+        let mut client =
+            Client::<Req, Resp>::new_retry(sock_path, Duration::from_millis(100)).await;
+
+        client
+            .send(Req {
+                foo: "test1".to_owned(),
+                bar: "test2".to_owned(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            client.next().await.unwrap().unwrap(),
+            Resp {
+                foo: "test2".to_owned(),
+                bar: "test1".to_owned(),
+            }
+        );
+
+        client
+            .send(Req {
+                foo: "test3".to_owned(),
+                bar: "test4".to_owned(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            client.next().await.unwrap().unwrap(),
+            Resp {
+                foo: "test4".to_owned(),
+                bar: "test3".to_owned(),
+            }
+        );
+
+        client
+            .send(Req {
+                foo: "test5".to_owned(),
+                bar: "test6".to_owned(),
+            })
+            .await
+            .unwrap();
+
+        client
+            .send(Req {
+                foo: "test7".to_owned(),
+                bar: "test8".to_owned(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            client.next().await.unwrap().unwrap(),
+            Resp {
+                foo: "test6".to_owned(),
+                bar: "test5".to_owned(),
+            }
+        );
+
+        assert_eq!(
+            client.next().await.unwrap().unwrap(),
+            Resp {
+                foo: "test8".to_owned(),
+                bar: "test7".to_owned(),
+            }
+        );
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,31 @@
+use std::time::Duration;
+
+/// The delay between retries starts at
+/// `min_backoff`, and doubles on each retry, until it reaches `max_backoff`. If
+/// the inner tasks at any point runs for longer than `current_backoff`, the
+/// backoff will reset back to `min_backoff`.
+pub async fn retry_with_backoff<T, F>(
+    backoff_bounds: std::ops::RangeInclusive<Duration>,
+    inner: impl Fn() -> F,
+) -> T
+where
+    F: Future<Output = Option<T>>,
+{
+    let mut backoff = *backoff_bounds.start();
+    loop {
+        let sleep = tokio::time::sleep(backoff);
+
+        if let Some(r) = inner().await {
+            break r;
+        }
+
+        if sleep.is_elapsed() {
+            // if we did run for at least backoff, reset and immediately retry.
+            backoff = *backoff_bounds.start();
+        } else {
+            // otherwise, wait, double the backoff, then retry.
+            sleep.await;
+            backoff = backoff.saturating_mul(2).min(*backoff_bounds.end());
+        }
+    }
+}


### PR DESCRIPTION
Changes:
* Switched from snafu to thiserr for errors
* moved `retry_with_backoff` into utils module
* simplified `retry_with_backoff` targeting a single usecase