### PR TITLE
Extend RobustClient for sending immediate messages.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -11,7 +11,7 @@ use tokio_util::codec::Framed;
 
 use crate::comm::{CodecError, PostcardCodec};
 
-pub use self::robust::{RobustClient, SplitSinkOwned, SplitStreamOwned};
+pub use self::robust::{RobustClient, borrowed, owned};
 
 /// Generic unix domain socket client. Takes a `Request` and `Response` types.
 /// The former is something sent to the server, the latter is what the server

--- a/src/client/robust.rs
+++ b/src/client/robust.rs
@@ -2,7 +2,6 @@ use std::{
     convert::Infallible,
     path::Path,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -12,6 +11,11 @@ use serde::{Serialize, de::DeserializeOwned};
 use tokio::sync::mpsc;
 use tokio_util::sync::{PollSendError, PollSender};
 
+pub mod borrowed;
+pub mod owned;
+
+use crate::one_slot_channel;
+
 use super::{Client, RetryInterval};
 
 type MappedPollSink<Request> =
@@ -20,7 +24,10 @@ type MappedPollSink<Request> =
 /// Robust client that will seamlessly reconnect on failures.
 pub struct RobustClient<Request, Response> {
     incoming: mpsc::Receiver<Response>,
-    outgoing: MappedPollSink<Request>,
+    /// Sink for requests with resilient delivery.
+    outgoing_resl: MappedPollSink<Request>,
+    /// Channel for constantly sent requests.
+    outgoing_live: one_slot_channel::Sender<Request>,
     client_loop: ChildTask<Never>,
 }
 
@@ -36,8 +43,9 @@ where
     ) -> Self {
         let socket_path = socket_path.to_owned();
         let (incoming_tx, incoming_rx) = mpsc::channel(10);
-        let (outgoing_tx, outgoing_rx) = mpsc::channel(10);
-        let mut out_stream = tokio_stream::wrappers::ReceiverStream::new(outgoing_rx);
+        let (outgoing_resl_tx, outgoing_resl_rx) = mpsc::channel(10);
+        let (outgoing_live_tx, outgoing_live_rx) = one_slot_channel::channel();
+        let mut out_resl_stream = tokio_stream::wrappers::ReceiverStream::new(outgoing_resl_rx);
         let client_loop = async move {
             let mut pending = None;
             'outer: loop {
@@ -45,8 +53,8 @@ where
                 let mut client =
                     Client::<Request, Response>::new_retry(&socket_path, retry_interval.clone())
                         .await;
-                let mut stream = futures::stream::iter(pending.take())
-                    .chain(&mut out_stream)
+                let mut out_resl_stream = futures::stream::iter(pending.take())
+                    .chain(&mut out_resl_stream)
                     .fuse();
                 loop {
                     tokio::select! {
@@ -55,13 +63,19 @@ where
                         // this is safe, if a tad inefficient. Generally, this
                         // won't happen, as recv-only stream is already
                         // implemented on Self.
-                        Some(next) = stream.next() => {
+                        Some(next) = out_resl_stream.next() => {
                             if let Err(e) = client.send(&next).await {
                                 pending = Some(next);
                                 tracing::error!(?e);
                                 continue 'outer;
                             }
                         },
+                        next = outgoing_live_rx.recv() => {
+                            if let Err(e) = client.send(&next).await {
+                                tracing::error!(?e);
+                                continue 'outer;
+                            }
+                        }
                         res = client.next() => {
                             let next = match res {
                                 Some(Ok(x)) => x,
@@ -83,42 +97,17 @@ where
         };
         Self {
             incoming: incoming_rx,
-            outgoing: PollSender::new(outgoing_tx).sink_map_err(|e| {
+            outgoing_resl: PollSender::new(outgoing_resl_tx).sink_map_err(|e| {
                 unreachable!("Error should be impossible here: {e}");
             }),
+            outgoing_live: outgoing_live_tx,
             client_loop: ChildTask::from(tokio::spawn(client_loop)),
         }
     }
 
     /// Produce a [Sink] for requests.
     pub fn sink(&mut self) -> impl Sink<Request, Error = Infallible> + use<'_, Request, Response> {
-        &mut self.outgoing
-    }
-
-    /// Produce a [Sink] for requests and [Stream] for responses. Borrowing
-    /// version. Should be slightly more efficient than [Self::split_owned].
-    pub fn split_borrowed(
-        &mut self,
-    ) -> (
-        impl Sink<Request, Error = Infallible> + use<'_, Request, Response>,
-        impl Stream<Item = Response> + use<'_, Request, Response>,
-    ) {
-        (&mut self.outgoing, SplitStream(&mut self.incoming))
-    }
-
-    /// Produce a [Sink] for requests and [Stream] for responses. Owned version.
-    pub fn split_owned(self) -> (SplitSinkOwned<Request>, SplitStreamOwned<Response>) {
-        let task = Arc::new(self.client_loop);
-        (
-            SplitSinkOwned {
-                inner: self.outgoing,
-                _task: Arc::clone(&task),
-            },
-            SplitStreamOwned {
-                inner: self.incoming,
-                _task: task,
-            },
-        )
+        &mut self.outgoing_resl
     }
 }
 
@@ -130,76 +119,5 @@ where
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.incoming.poll_recv(cx)
-    }
-}
-
-struct SplitStream<'a, T>(&'a mut mpsc::Receiver<T>);
-
-impl<T> Stream for SplitStream<'_, T> {
-    type Item = T;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.0.poll_recv(cx)
-    }
-}
-
-/// The sink part of the [RobustClient], owned version.
-pub struct SplitSinkOwned<Request> {
-    inner: MappedPollSink<Request>,
-    _task: Arc<ChildTask<Never>>,
-}
-
-impl<Request> SplitSinkOwned<Request> {
-    /// A convenient function to send message once, using only shared reference,
-    /// unlike [SinkExt::send].
-    #[expect(clippy::missing_panics_doc)]
-    pub async fn send_ref(&self, msg: Request)
-    where
-        Request: Send,
-    {
-        self.inner
-            .get_ref()
-            .get_ref()
-            .expect("Must be open by construction")
-            .send(msg)
-            .await
-            .expect("Receiver part isn't dropped until self");
-    }
-}
-
-impl<Request> Sink<Request> for SplitSinkOwned<Request>
-where
-    MappedPollSink<Request>: Sink<Request, Error = Infallible> + Unpin,
-{
-    type Error = Infallible;
-
-    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready_unpin(cx)
-    }
-
-    fn start_send(mut self: Pin<&mut Self>, item: Request) -> Result<(), Self::Error> {
-        self.inner.start_send_unpin(item)
-    }
-
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_flush_unpin(cx)
-    }
-
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_close_unpin(cx)
-    }
-}
-
-/// The stream part of the [RobustClient], owned version.
-pub struct SplitStreamOwned<Response> {
-    inner: mpsc::Receiver<Response>,
-    _task: Arc<ChildTask<Never>>,
-}
-
-impl<Response> Stream for SplitStreamOwned<Response> {
-    type Item = Response;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.inner.poll_recv(cx)
     }
 }

--- a/src/client/robust/borrowed.rs
+++ b/src/client/robust/borrowed.rs
@@ -1,0 +1,76 @@
+//! Helper types carrying parts of [super::RobustClient], borrowed version.
+use std::{
+    convert::Infallible,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::{Sink, SinkExt, Stream};
+use serde::{Serialize, de::DeserializeOwned};
+use tokio::sync::mpsc;
+
+use crate::{one_slot_channel, utils::sink_via_unpin};
+
+use super::MappedPollSink;
+
+/// The stream part of the [super::RobustClient].
+pub struct SplitStream<'a, T>(&'a mut mpsc::Receiver<T>);
+
+impl<T> Stream for SplitStream<'_, T> {
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.0.poll_recv(cx)
+    }
+}
+
+/// The combination of [super::RobustClient]'s sinks.
+pub struct SplitSink<'a, Request> {
+    /// Sink with resilient delivery.
+    pub resilient: ResilientSplitSink<'a, Request>,
+    /// Sink for cases when requests are sent constantly, and only the recent
+    /// request is relevant. Requests will not be preserved on reconnection.
+    pub live: LiveSplitSink<'a, Request>,
+}
+
+/// The resilient sink part of the [super::RobustClient].
+pub struct ResilientSplitSink<'a, Request>(&'a mut MappedPollSink<Request>);
+
+/// The live sink part of the [super::RobustClient].
+pub struct LiveSplitSink<'a, Request>(&'a one_slot_channel::Sender<Request>);
+
+impl<Request> Sink<Request> for ResilientSplitSink<'_, Request>
+where
+    MappedPollSink<Request>: Sink<Request, Error = Infallible> + Unpin,
+{
+    type Error = Infallible;
+    sink_via_unpin!(0);
+}
+
+impl<Request> Sink<Request> for LiveSplitSink<'_, Request> {
+    type Error = Infallible;
+    sink_via_unpin!(0);
+}
+
+impl<Request, Response> super::RobustClient<Request, Response>
+where
+    Response: DeserializeOwned + Send + 'static,
+    Request: Serialize + Send + Sync + 'static,
+{
+    /// Produce a [SplitSink] containing several [Sink]s for requests and
+    /// [Stream] for responses. Borrowed version.
+    pub fn split_borrowed(
+        &mut self,
+    ) -> (
+        SplitSink<Request>,
+        impl Stream<Item = Response> + use<'_, Request, Response>,
+    ) {
+        (
+            SplitSink {
+                resilient: ResilientSplitSink(&mut self.outgoing_resl),
+                live: LiveSplitSink(&self.outgoing_live),
+            },
+            SplitStream(&mut self.incoming),
+        )
+    }
+}

--- a/src/client/robust/owned.rs
+++ b/src/client/robust/owned.rs
@@ -1,0 +1,110 @@
+//! Helper types carrying parts of [super::RobustClient], owned version.
+use std::{
+    convert::Infallible,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use abort_on_drop::ChildTask;
+use futures::{Sink, SinkExt, Stream, never::Never};
+use serde::{Serialize, de::DeserializeOwned};
+use tokio::sync::mpsc;
+
+use crate::{one_slot_channel, utils::sink_via_unpin};
+
+use super::MappedPollSink;
+
+/// The stream part of the [super::RobustClient].
+pub struct SplitStream<Response> {
+    inner: mpsc::Receiver<Response>,
+    _task: Arc<ChildTask<Never>>,
+}
+
+impl<Response> Stream for SplitStream<Response> {
+    type Item = Response;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.poll_recv(cx)
+    }
+}
+
+/// The combination of [super::RobustClient]'s sinks.
+pub struct SplitSink<Request> {
+    /// Sink with resilient delivery.
+    pub resilient: SplitResilientSink<Request>,
+    /// Sink for cases when requests are sent constantly, and only the recent
+    /// request is relevant. Requests will not be preserved on reconnection.
+    pub live: SplitLiveSink<Request>,
+}
+
+/// The resilient sink part of the [super::RobustClient].
+pub struct SplitResilientSink<Request> {
+    inner: MappedPollSink<Request>,
+    _task: Arc<ChildTask<Never>>,
+}
+
+impl<Request> SplitResilientSink<Request> {
+    /// A convenient function to send message once, using only shared reference,
+    /// unlike [SinkExt::send].
+    #[expect(clippy::missing_panics_doc)]
+    pub async fn send_ref(&self, msg: Request)
+    where
+        Request: Send,
+    {
+        self.inner
+            .get_ref()
+            .get_ref()
+            .expect("Must be open by construction")
+            .send(msg)
+            .await
+            .expect("Receiver part isn't dropped until self");
+    }
+}
+
+impl<Request> Sink<Request> for SplitResilientSink<Request>
+where
+    MappedPollSink<Request>: Sink<Request, Error = Infallible> + Unpin,
+{
+    type Error = Infallible;
+    sink_via_unpin!(inner);
+}
+
+/// The live sink part of the [super::RobustClient].
+pub struct SplitLiveSink<Request> {
+    inner: one_slot_channel::Sender<Request>,
+    _task: Arc<ChildTask<Never>>,
+}
+
+impl<Request> Sink<Request> for SplitLiveSink<Request> {
+    type Error = Infallible;
+    sink_via_unpin!(inner);
+}
+
+impl<Request, Response> super::RobustClient<Request, Response>
+where
+    Response: DeserializeOwned + Send + 'static,
+    Request: Serialize + Send + Sync + 'static,
+{
+    /// Produce a [SplitSink] containing several [Sink]s for requests and
+    /// [Stream] for responses. Owned version.
+    pub fn split_owned(self) -> (SplitSink<Request>, SplitStream<Response>) {
+        let task = Arc::new(self.client_loop);
+        (
+            SplitSink {
+                resilient: SplitResilientSink {
+                    inner: self.outgoing_resl,
+                    _task: Arc::clone(&task),
+                },
+                live: SplitLiveSink {
+                    inner: self.outgoing_live,
+                    _task: Arc::clone(&task),
+                },
+            },
+            SplitStream {
+                inner: self.incoming,
+                _task: task,
+            },
+        )
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,12 @@
 
 mod client;
 mod comm;
+mod one_slot_channel;
 mod server;
 pub(crate) mod utils;
 
-pub use client::{Client, RobustClient, RobustType, ServerType, SplitSinkOwned, SplitStreamOwned};
+pub use client::borrowed as client_borrowed;
+pub use client::owned as client_owned;
+pub use client::{Client, RobustClient, RobustType, ServerType};
 pub use comm::CodecError;
 pub use server::{Error, IndependentHandlers, RequestStream, Server, independent_handlers, serve};

--- a/src/one_slot_channel.rs
+++ b/src/one_slot_channel.rs
@@ -1,0 +1,106 @@
+//! Channel preserving only the last sent value.
+use std::{
+    convert::Infallible,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::{Context, Poll},
+};
+
+use futures::Sink;
+use tokio::sync::Notify;
+
+/// Create a channel that preserves only the last value sent to it.
+///
+/// Unlike `watch`, it doesn't require values to be `Clone`.
+///
+/// It also does not support closing, on either end. Meaning that reading from
+/// receiver end will block indefinitely if the sender end is dropped.
+pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
+    let inner = Arc::new(Inner {
+        slot: Mutex::new(None),
+        notify: Notify::new(),
+    });
+    (Sender(inner.clone()), Receiver(inner))
+}
+
+struct Inner<T> {
+    slot: Mutex<Option<T>>,
+    notify: Notify,
+}
+
+/// Sender end of the channel.
+///
+/// Implements `[Sink]`.
+pub struct Sender<T>(Arc<Inner<T>>);
+
+impl<T> Sender<T> {
+    /// Send a value to the channel.
+    pub fn send(&self, v: T) {
+        *self.0.slot.lock().expect("Poisoned Mutex") = Some(v);
+        self.0.notify.notify_one();
+    }
+}
+
+impl<T> Sink<T> for &Sender<T> {
+    type Error = Infallible;
+
+    fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
+        self.send(item);
+        Ok(())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl<T> Sink<T> for Sender<T> {
+    type Error = Infallible;
+
+    fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
+        self.send(item);
+        Ok(())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+/// Receiver end of the channel.
+///
+/// Reading from receiver once sender has been dropped will block indefinitely.
+pub struct Receiver<T>(Arc<Inner<T>>);
+
+impl<T> Receiver<T> {
+    /// Receive a value.
+    ///
+    /// If at the moment of this call the channel contains an unseen value,
+    /// it will be returned. Otherwise this will block until new value is
+    /// sent.
+    pub async fn recv(&self) -> T {
+        loop {
+            self.0.notify.notified().await;
+            let val = self.0.slot.lock().expect("Poisoned Mutex").take();
+            if let Some(val) = val {
+                break val;
+            }
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,3 +29,34 @@ where
         }
     }
 }
+
+macro_rules! sink_via_unpin {
+    ($field:tt) => {
+        fn poll_ready(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            self.$field.poll_ready_unpin(cx)
+        }
+
+        fn start_send(mut self: Pin<&mut Self>, item: Request) -> Result<(), Self::Error> {
+            self.$field.start_send_unpin(item)
+        }
+
+        fn poll_flush(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            self.$field.poll_flush_unpin(cx)
+        }
+
+        fn poll_close(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            self.$field.poll_close_unpin(cx)
+        }
+    };
+}
+
+pub(crate) use sink_via_unpin;


### PR DESCRIPTION
Problem: sometimes you are ok with messages being dropped while the client reconnects. Currently they are buffered and sent on reconnection.

For this we need a channel that will keep only one, preferably the most
recent element. Could use `watch` or `broadcast::channel(1)`, but they
require `Clone` on the chanelled items.

Solution: add a dedicated `one_slot` channel implementation based on
`Mutex<Option<T>>` and `Notify`.