### PR TITLE
Chore: simplify branch protection setup

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -75,3 +75,13 @@ jobs:
     - run: |
         nix build -L --no-link .#checks.x86_64-linux.${{ matrix.check }} \
           --extra-substituters file://$PWD/nix-store?trusted=true
+
+  required:
+    needs:
+    - check
+    - flake-check
+    runs-on: ubuntu-latest
+    name: Faux required check
+    steps:
+    - run: |
+        true


### PR DESCRIPTION
Problem: required checks are a chore to set up

Solution: Add a single required job with dependencies defined in yaml.