### PR TITLE
Chore: fix faux CI job

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -82,6 +82,14 @@ jobs:
     - flake-check
     runs-on: ubuntu-latest
     name: Faux required check
+    if: always()
     steps:
-    - run: |
-        true
+      - name: Fail if any dependency failed or was skipped
+        run: |
+          all_ok=$(jq 'all(.[]; .result == "success")' <<'EOF'
+          ${{ toJson(needs) }}
+          EOF
+          )
+          if [ "$all_ok" != "true" ]; then
+            exit 1
+          fi


### PR DESCRIPTION
Problem: apparently github ignores skipped required checks.

Solution: force faux check to run and check that dependencies succeeded.